### PR TITLE
Add code coverage and badge(s)

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,3 +17,5 @@ checks:
         fix_identation_4spaces: true
         fix_doc_comments: true
 
+tools:
+    external_code_coverage: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
 
 env:
   matrix:
@@ -17,4 +18,5 @@ script:
   - phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
-  - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![StyleCI](https://styleci.io/repos/65542206/shield)](https://styleci.io/repos/65542206)
 [![SensioLabsInsight](https://img.shields.io/sensiolabs/i/6ac8b6d5-c215-4ba5-9a47-d1b312ec196d.svg?style=flat-square)](https://insight.sensiolabs.com/projects/6ac8b6d5-c215-4ba5-9a47-d1b312ec196d)
 [![Quality Score](https://img.shields.io/scrutinizer/g/laravel-notification-channels/webpush.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/webpush)
+[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/webpush/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/webpush/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/webpush.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/webpush)
 
 This package makes it easy to send web push notifications with Laravel 5.3.
@@ -114,7 +115,7 @@ $user->deletePushSubscription($endpoint);
 
 ## Demo
 
-For a complete implementation with a Service Worker check this [demo](https://github.com/cretueusebiu/laravel-web-push-demo). 
+For a complete implementation with a Service Worker check this [demo](https://github.com/cretueusebiu/laravel-web-push-demo).
 
 ## Browser Compatibility
 
@@ -125,7 +126,7 @@ The [Push API](https://developer.mozilla.org/en/docs/Web/API/Push_API) currently
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
 
 ## Testing
-    
+
 ``` bash
 $ composer test
 ```


### PR DESCRIPTION
This PR brings this repository up to date with recent changes in the skeleton. The primary part of this PR is a code coverage set up and badge (https://github.com/laravel-notification-channels/skeleton/pull/6).

Also, if this repository did not have the following already, I have:
- added PHP 7.1 to .travis.yml
- fixed a typo in the changelog