### PR TITLE
PHP 7.2 compatibility fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.6.4",
         "illuminate/notifications": "^5.3",
         "illuminate/support": "^5.1",
-        "minishlink/web-push": "^1.4.1"
+        "minishlink/web-push": "^2.0.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",


### PR DESCRIPTION
Hey, guys!

One of the deeper dependencies (`fgrosse/PHPASN1@1.5.2`) is incompatible with PHP 7.2 See issue https://github.com/fgrosse/PHPASN1/issues/65.

They fixed it, but it has lead to a major version increment.
The dependency chain: `laravel-notification-channels/webpush` > `minishlink/web-push` > `mdanter/ecc` > `fgrosse/phpasn1`

I propose to increment `minishlink/web-push` dependency version so that we will end up with `fgrosse/phpasn1` compatible with php7.2 and above.

`composer test` went green `20 / 20 (100%)`