### PR TITLE
Increase endpoint column length, 255 isn't enough

### DIFF
--- a/migrations/create_push_subscriptions_table.php.stub
+++ b/migrations/create_push_subscriptions_table.php.stub
@@ -16,7 +16,7 @@ class CreatePushSubscriptionsTable extends Migration
         Schema::create('push_subscriptions', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('user_id')->unsigned()->index();
-            $table->string('endpoint')->unique();
+            $table->string('endpoint', 500)->unique();
             $table->string('public_key')->nullable();
             $table->string('auth_token')->nullable();
             $table->timestamps();


### PR DESCRIPTION
I had a case with an endpoint of 411 characters:

https://bl2p.notify.windows.com/w/?token=XXXXXXXMJjpvgKMZ%XfQPDL3vGaB6YEIWVgveLd7mRONBbXDnMzmXpWrbGoLkKC4g0kYxRgOV5tikw9z%XfL47iAmlWXkcnlKF7juN3ZMPvghUBFSzX%XXXXXXXAQxaODL3SNqCrmW9CIpCMIqEb8aGwSGzF45sbK2Era7%2fi97Yf2pKQsXak5kmW%XXQg8O8M7H0OgOXlvjtnCAIGkdcExB2VtVyJ881CMil2jHR7%XXXJ6PmD1Ps5xOld7pBOlgMsOFr51kudTVwCJhlJrOu9K6LOS5G2QgVsTbzyVAiKUMAbHx%XXS4ZBKl0hwXX%XXXXX%2bMbnD1eCEaoISeYH87y%2faMV1OMNKbzEMN%XXXXXX

(replaced some chars with 'X')