### PR TITLE
Replace mapWithKeys with map

### DIFF
--- a/src/WebPushMessage.php
+++ b/src/WebPushMessage.php
@@ -260,7 +260,7 @@ class WebPushMessage
             'vibrate',
             'data',
         ])
-        ->mapWithKeys(function ($option) {
+        ->map(function ($option) {
             return [$option => $this->{$option}];
         })
         ->reject(function ($value) {


### PR DESCRIPTION
The mapWithKeys method is supported by Laravel 5.3 and higher. Replacing it with map makes it available for older versions as well.