### PR TITLE
Bugfix

### DIFF
--- a/src/WebPushChannel.php
+++ b/src/WebPushChannel.php
@@ -30,7 +30,7 @@ class WebPushChannel
     {
         $subscriptions = $notifiable->routeNotificationFor('WebPush');
 
-        if ($subscriptions->isEmpty()) {
+        if (! $subscriptions || $subscriptions->isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
Laravel will notify all routes, even if a notification is being sent through a single route only, like:
```
Notification::route('nexmo', $number)->notify(new Notification());
```
Will also invoke the send method of WebPushChannel, but the array key won't exist, and thus it throws an exception when trying to call ->isEmpty()