### PR TITLE
Add option to enable logging output

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ $user = \App\User::find(1);
 $user->deletePushSubscription($endpoint);
 ```
 
+## Debugging
+
+If you are having trouble sending messages you can enable verbose logging by setting the `WEBPUSH_ENABLE_LOG` to `true`. This can also be set in `config('webpush.enable_logging')`.
+
 ## Demo
 
 For a complete implementation with a Service Worker check this [demo](https://github.com/cretueusebiu/laravel-web-push-demo).

--- a/config/webpush.php
+++ b/config/webpush.php
@@ -42,6 +42,6 @@ return [
     |
     */
 
-    'log_errors' => env('WEBPUSH_LOG_ERRORS', false),
+    'enable_logging' => env('WEBPUSH_ENABLE_LOG', false),
 
 ];

--- a/config/webpush.php
+++ b/config/webpush.php
@@ -33,4 +33,15 @@ return [
         'sender_id' => env('GCM_SENDER_ID'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Log Errors
+    |--------------------------------------------------------------------------
+    |
+    | Logs errors if webpush server reports an error when posting
+    |
+    */
+
+    'log_errors' => env('WEBPUSH_LOG_ERRORS', false),
+
 ];

--- a/src/WebPushChannel.php
+++ b/src/WebPushChannel.php
@@ -2,6 +2,7 @@
 
 namespace NotificationChannels\WebPush;
 
+use Illuminate\Support\Facades\Log;
 use Minishlink\WebPush\WebPush;
 use Illuminate\Notifications\Notification;
 
@@ -47,6 +48,8 @@ class WebPushChannel
 
         $response = $this->webPush->flush();
 
+        $this->logErrorsInDebug($response);
+
         $this->deleteInvalidSubscriptions($response, $subscriptions);
     }
 
@@ -66,5 +69,20 @@ class WebPushChannel
                 $subscriptions[$index]->delete();
             }
         }
+    }
+
+    protected function logErrorsInDebug($response)
+    {
+		if(config('webpush.log_errors')){
+			if(!is_array($response)){
+				return;
+			}
+
+			foreach($response as $push){
+				if(!$push['success']){
+					Log::error("[WebPush] Error pushing: {$push['message']}\nEndpoint: {$push['endpoint']}");
+				}
+			}
+		}
     }
 }


### PR DESCRIPTION
Gives the user a more verbose output of messages sent/not sent and the error reason why. 

Updated README to document how to turn on. The default is disabled.