### PR TITLE
added ability to customize table and connection for push subscriptions

### DIFF
--- a/config/webpush.php
+++ b/config/webpush.php
@@ -33,4 +33,25 @@ return [
         'sender_id' => env('GCM_SENDER_ID'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Database Table
+    |--------------------------------------------------------------------------
+    |
+    | If you want to change the name of the subscriptions table
+    |
+    */
+
+    'db_table' => env('WEBPUSH_TABLE', 'push_subscriptions'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | If you want to change the connection of the subscriptions table
+    |
+    */
+
+    'db_connection' => env('WEBPUSH_CONNECTION'),
 ];

--- a/migrations/create_push_subscriptions_table.php.stub
+++ b/migrations/create_push_subscriptions_table.php.stub
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use NotificationChannels\WebPush\PushSubscription;
 
 class CreatePushSubscriptionsTable extends Migration
 {
@@ -13,7 +14,7 @@ class CreatePushSubscriptionsTable extends Migration
      */
     public function up()
     {
-        Schema::create('push_subscriptions', function (Blueprint $table) {
+        Schema::connection((new PushSubscription)->getConnectionName())->create(config('webpush.db_table'), function (Blueprint $table) {
             $table->increments('id');
             $table->integer('user_id')->unsigned()->index();
             $table->string('endpoint', 500)->unique();
@@ -35,6 +36,6 @@ class CreatePushSubscriptionsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('push_subscriptions');
+        Schema::connection((new PushSubscription)->getConnectionName())->drop(config('webpush.db_table'));
     }
 }

--- a/src/PushSubscription.php
+++ b/src/PushSubscription.php
@@ -18,6 +18,26 @@ class PushSubscription extends Model
         'auth_token',
     ];
 
+    public function __construct(array $attributes = [])
+    {
+        if (!isset($this->table)) {
+            $this->setTable(config('webpush.db_table'));
+        }
+
+        parent::__construct($attributes);
+    }
+
+    /**
+     * Get the connection name for the push subscriptions.
+     *
+     * @return string
+     */
+    public function getConnectionName()
+    {
+        $connName = config('webpush.db_connection');
+        return $connName ?: config('database.default');
+    }
+
     /**
      * Get the user that owns the subscription.
      *


### PR DESCRIPTION
in my project I use a separate connection to hold things like notifications and subscriptions, this simply adds the ability to configure which table and connection is tied to the push subscriptions model