### PR TITLE
Add `options` property to WebPushMessage

### DIFF
--- a/src/WebPushChannel.php
+++ b/src/WebPushChannel.php
@@ -34,14 +34,24 @@ class WebPushChannel
             return;
         }
 
-        $payload = json_encode($notification->toWebPush($notifiable, $notification)->toArray());
+        $webPushMessage = $notification->toWebPush($notifiable, $notification);
+        $webPushMessageArr = $webPushMessage->toArray();
+        
+        $options = [];
+        if(isset($webPushMessageArr['options'])) {
+            $options = $webPushMessageArr['options'];
+            unset($webPushMessageArr['options']);
+        }
 
-        $subscriptions->each(function ($sub) use ($payload) {
+        $payload = json_encode($webPushMessageArr);
+
+        $subscriptions->each(function ($sub) use ($payload, $options) {
             $this->webPush->sendNotification(
                 $sub->endpoint,
                 $payload,
                 $sub->public_key,
-                $sub->auth_token
+                $sub->auth_token,
+                $options
             );
         });
 

--- a/src/WebPushChannel.php
+++ b/src/WebPushChannel.php
@@ -36,9 +36,9 @@ class WebPushChannel
 
         $webPushMessage = $notification->toWebPush($notifiable, $notification);
         $webPushMessageArr = $webPushMessage->toArray();
-        
+
         $options = [];
-        if(isset($webPushMessageArr['options'])) {
+        if (isset($webPushMessageArr['options'])) {
             $options = $webPushMessageArr['options'];
             unset($webPushMessageArr['options']);
         }

--- a/src/WebPushMessage.php
+++ b/src/WebPushMessage.php
@@ -73,6 +73,11 @@ class WebPushMessage
     protected $data;
 
     /**
+     * @var mixed
+     */
+    protected $options;
+
+    /**
      * Set the notification title.
      *
      * @param  string $value
@@ -234,6 +239,19 @@ class WebPushMessage
     public function data($value)
     {
         $this->data = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the notification options.
+     *
+     * @param  mixed $value
+     * @return $this
+     */
+    public function options($value)
+    {
+        $this->options = $value;
 
         return $this;
     }

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -34,7 +34,7 @@ class ChannelTest extends TestCase
     {
         $this->webPush->shouldReceive('sendNotification')
             ->once()
-            ->with('endpoint', $this->getPayload(), 'key', 'token')
+            ->with('endpoint', $this->getPayload(), 'key', 'token', [])
             ->andReturn(true);
 
         $this->webPush->shouldReceive('flush')
@@ -53,12 +53,12 @@ class ChannelTest extends TestCase
     {
         $this->webPush->shouldReceive('sendNotification')
             ->once()
-            ->with('valid_endpoint', $this->getPayload(), null, null)
+            ->with('valid_endpoint', $this->getPayload(), null, null, [])
             ->andReturn(true);
 
         $this->webPush->shouldReceive('sendNotification')
             ->once()
-            ->with('invalid_endpoint', $this->getPayload(), null, null)
+            ->with('invalid_endpoint', $this->getPayload(), null, null, [])
             ->andReturn(true);
 
         $this->webPush->shouldReceive('flush')
@@ -76,6 +76,25 @@ class ChannelTest extends TestCase
         $this->assertFalse($this->testUser->pushSubscriptions()->where('endpoint', 'invalid_endpoint')->exists());
 
         $this->assertTrue($this->testUser->pushSubscriptions()->where('endpoint', 'valid_endpoint')->exists());
+    }
+
+    /** @test */
+    public function it_can_send_a_notification_with_options()
+    {
+        $this->webPush->shouldReceive('sendNotification')
+            ->once()
+            ->with('endpoint', $this->getPayload(), 'key', 'token', ['ttl' => 60])
+            ->andReturn(true);
+
+        $this->webPush->shouldReceive('flush')
+            ->once()
+            ->andReturn(true);
+
+        $this->testUser->updatePushSubscription('endpoint', 'key', 'token');
+
+        $this->channel->send($this->testUser, new TestNotificationWithOptions);
+
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -120,4 +120,12 @@ class MessageTest extends TestCase
 
         $this->assertEquals(['id' => 1], $this->message->toArray()['data']);
     }
+
+    /** @test */
+    public function can_set_options()
+    {
+        $this->message->options(['ttl' => 60]);
+
+        $this->assertEquals(['ttl' => 60], $this->message->toArray()['options']);
+    }
 }

--- a/tests/TestNotificationWithOptions.php
+++ b/tests/TestNotificationWithOptions.php
@@ -2,8 +2,6 @@
 
 namespace NotificationChannels\WebPush\Test;
 
-use NotificationChannels\WebPush\WebPushMessage;
-
 class TestNotificationWithOptions extends TestNotification
 {
     /**

--- a/tests/TestNotificationWithOptions.php
+++ b/tests/TestNotificationWithOptions.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace NotificationChannels\WebPush\Test;
+
+use NotificationChannels\WebPush\WebPushMessage;
+
+class TestNotificationWithOptions extends TestNotification
+{
+    /**
+     * Get the web push representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @param  mixed  $notification
+     * @return \NotificationChannels\WebPush\WebPushMessage
+     */
+    public function toWebPush($notifiable, $notification)
+    {
+        return parent::toWebPush($notifiable, $notification)
+            ->options(['ttl' => 60]);
+    }
+}


### PR DESCRIPTION
`web-push-libs/web-push-php` allows you to add some custom options (for example I need to send TTL header) when sending notifications (https://github.com/web-push-libs/web-push-php/tree/v2.0.1#notifications-and-default-options). 

This PR add a new property on WebPushMessage that could incapsulate these options in order to be more flexible.