### PR TITLE
Allow Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     ],
     "require": {
         "php": "^7.1",
-        "illuminate/notifications": "^5.3",
-        "illuminate/support": "^5.1",
+        "illuminate/notifications": "^5.3|^6.0",
+        "illuminate/support": "^5.1|^6.0",
         "minishlink/web-push": "^5.0"
     },
     "require-dev": {
         "mockery/mockery": "~1.0",
-        "phpunit/phpunit": "~7.0",
-        "orchestra/testbench": "^3.5"
+        "orchestra/testbench": "^4.0",
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -92,6 +92,6 @@ abstract class TestCase extends Orchestra
     {
         $consoleOutput = $this->app[Kernel::class]->output();
 
-        $this->assertContains($expectedText, $consoleOutput, "Did not see `{$expectedText}` in console output: `$consoleOutput`");
+        $this->assertStringContainsString($expectedText, $consoleOutput, "Did not see `{$expectedText}` in console output: `$consoleOutput`");
     }
 }


### PR DESCRIPTION
From what I can tell, the package works completely fine when using it with Laravel 6.0 (tests are passing, and I didn't come across anything unexpected while trying in a Laravel 6.0 application).

`orchestra/testbench` requires a newer version of PHPUnit, and that marks `assertContains` as deprecated, so I also had to change that.