### PR TITLE
Updated routeNotificationFor call

### DIFF
--- a/src/WebPushChannel.php
+++ b/src/WebPushChannel.php
@@ -39,7 +39,7 @@ class WebPushChannel
     public function send($notifiable, Notification $notification)
     {
         /** @var \Illuminate\Database\Eloquent\Collection $subscriptions */
-        $subscriptions = $notifiable->routeNotificationFor('WebPush');
+        $subscriptions = $notifiable->routeNotificationFor('WebPush', $notification);
 
         if (empty($subscriptions)) {
             return;


### PR DESCRIPTION
In the situation where ```routeNotificationForWebPush()``` is overridden, Laravel can pass the notification to ```routeNotificationFor()``` [since 5.6](https://laravel.com/api/5.6/Illuminate/Notifications/RoutesNotifications.html). 
.
Currently to override this method to use the notification requires overriding some combination of 
 ```routeNotificationForWebPush()``` method (or trait), the Channel, and the Service Provider. With this change, only the ```routeNotificationForWebPush()``` method needs to be overridden.
.
Possible additional change would be to change the default ```routeNotificationForWebPush()``` to accept the $notification, even though it is not being used in the core library. It would have to be optional for version support.