### PR TITLE
update to web-push-php-v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^7.2",
         "illuminate/notifications": "^5.3|^6.0|^7.0",
         "illuminate/support": "^5.1|^6.0|^7.0",
-        "minishlink/web-push": "^5.0"
+        "minishlink/web-push": "^6.0"
     },
     "require-dev": {
         "mockery/mockery": "~1.0",

--- a/src/WebPushChannel.php
+++ b/src/WebPushChannel.php
@@ -52,12 +52,12 @@ class WebPushChannel
 
         /** @var \NotificationChannels\WebPush\PushSubscription $subscription */
         foreach ($subscriptions as $subscription) {
-            $this->webPush->sendNotification(new Subscription(
+            $this->webPush->queueNotification(new Subscription(
                 $subscription->endpoint,
                 $subscription->public_key,
                 $subscription->auth_token,
                 $subscription->content_encoding
-            ), $payload, false, $options);
+            ), $payload, $options);
         }
 
         $reports = $this->webPush->flush();

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -32,9 +32,9 @@ class ChannelTest extends TestCase
     {
         $message = ($notification = new TestNotification)->toWebPush(null, null);
 
-        $this->webPush->shouldReceive('sendNotification')
+        $this->webPush->shouldReceive('queueNotification')
             ->once()
-            ->withArgs(function (Subscription $subscription, string $payload, bool $flush, array $options = []) use ($message) {
+            ->withArgs(function (Subscription $subscription, string $payload, array $options = [], array $auth = []) use ($message) {
                 $this->assertInstanceOf(Subscription::class, $subscription);
                 $this->assertEquals('endpoint', $subscription->getEndpoint());
                 $this->assertEquals('key', $subscription->getPublicKey());
@@ -61,7 +61,7 @@ class ChannelTest extends TestCase
     /** @test */
     public function subscriptions_with_invalid_endpoint_are_deleted()
     {
-        $this->webPush->shouldReceive('sendNotification')
+        $this->webPush->shouldReceive('queueNotification')
             ->times(3);
 
         $this->webPush->shouldReceive('flush')


### PR DESCRIPTION
Upgrades web-push-php dependency to v6 which brings support for web-token v2.