### PR TITLE
Check if subscriptions exists

### DIFF
--- a/src/WebPushChannel.php
+++ b/src/WebPushChannel.php
@@ -41,7 +41,7 @@ class WebPushChannel
         /** @var \Illuminate\Database\Eloquent\Collection $subscriptions */
         $subscriptions = $notifiable->routeNotificationFor('WebPush', $notification);
 
-        if (empty($subscriptions)) {
+        if ($subscriptions->isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
empty() replaced by isEmpty() since empty() does not work for a collection instance.