### PR TITLE
Support PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "illuminate/notifications": "^5.3|^6.0|^7.0|^8.0",
         "illuminate/support": "^5.1|^6.0|^7.0|^8.0",
         "minishlink/web-push": "^6.0"


### PR DESCRIPTION
Reviewed [PHP 8 migration guide](https://www.php.net/manual/en/migration80.php) with no conflicts noted.  All tests passing on PHP 8.0.