### PR TITLE
chore: change supported versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [7.3, 7.4, 8.0, 8.1]
 
     name: PHP ${{ matrix.php }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,16 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1]
+        php: [8.1, 8.0]
+        laravel: [9.*, 8.*]
+        stability: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 9.*
+            testbench: 7.*
+          - laravel: 8.*
+            testbench: ^6.23
 
-    name: PHP ${{ matrix.php }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -29,7 +36,7 @@ jobs:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.php }}-composer-
+            ${{ runner.os }}-P${{ matrix.php }}-L${{ matrix.laravel }}-composer-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -39,11 +46,9 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 2
-          max_attempts: 2
-          command: composer install --prefer-dist --no-interaction --no-progress --ignore-platform-reqs
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
-        "illuminate/notifications": "^5.3|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^5.1|^6.0|^7.0|^8.0|^9.0",
+        "php": "^8.0",
+        "illuminate/notifications": "^8.0|^9.0",
+        "illuminate/support": "^8.0|^9.0",
         "minishlink/web-push": "^6.0"
     },
     "require-dev": {
         "mockery/mockery": "~1.0",
-        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",
-        "phpunit/phpunit": "^8.5|^9.0"
+        "orchestra/testbench": "^6.0|^7.0",
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "illuminate/notifications": "^5.3|^6.0|^7.0|^8.0",
-        "illuminate/support": "^5.1|^6.0|^7.0|^8.0",
+        "illuminate/notifications": "^5.3|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/support": "^5.1|^6.0|^7.0|^8.0|^9.0",
         "minishlink/web-push": "^6.0"
     },
     "require-dev": {
         "mockery/mockery": "~1.0",
-        "orchestra/testbench": "^4.0",
-        "phpunit/phpunit": "^8.5"
+        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",
+        "phpunit/phpunit": "^8.5|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,33 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" />
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <php>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
+  <php>
+    <env name="DB_CONNECTION" value="sqlite"/>
+    <env name="DB_DATABASE" value=":memory:"/>
+  </php>
 </phpunit>

--- a/tests/VapidKeysGenerateCommandTest.php
+++ b/tests/VapidKeysGenerateCommandTest.php
@@ -46,7 +46,7 @@ class VapidKeysGenerateCommandTest extends TestCase
 
         $envContents = file_get_contents($envPath);
 
-        $this->assertRegExp('/^VAPID_PUBLIC_KEY=/m', $envContents);
-        $this->assertRegExp('/^VAPID_PRIVATE_KEY=/m', $envContents);
+        $this->assertMatchesRegularExpression('/^VAPID_PUBLIC_KEY=/m', $envContents);
+        $this->assertMatchesRegularExpression('/^VAPID_PRIVATE_KEY=/m', $envContents);
     }
 }


### PR DESCRIPTION
Replaces #167.

This is a breaking change because it drops support for older Laravel-versions (will support Laravel >8.0) and it will only support PHP >8.0. It also fixes some deprecation warnings from PHPunit.