### PR TITLE
chore: upgrade web-push to v7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^8.0",
         "illuminate/notifications": "^8.0|^9.0",
         "illuminate/support": "^8.0|^9.0",
-        "minishlink/web-push": "^6.0"
+        "minishlink/web-push": "^7.0"
     },
     "require-dev": {
         "mockery/mockery": "~1.0",


### PR DESCRIPTION
This upgrades the dependency web-push to v7.0. The only breaking change in that dependency is that PHP 7.3 support has been dropped, which souldn't be a problem because this project requires PHP 8.0 or higher.