### PR TITLE
Allow to set WebPush automatic padding in config

### DIFF
--- a/config/webpush.php
+++ b/config/webpush.php
@@ -34,12 +34,12 @@ return [
      * The Guzzle client options used by Minishlink\WebPush.
      */
     'client_options' => [],
-    
+
     /**
      * The automatic padding in bytes used by Minishlink\WebPush.
-     * Set to false to support Firefox Android with v1 endpoint 
+     * Set to false to support Firefox Android with v1 endpoint.
      */
-    'automatic_padding' => 3052,
+    'automatic_padding' => env('WEBPUSH_AUTOMATIC_PADDING', true),
 
     /**
      * Google Cloud Messaging.

--- a/config/webpush.php
+++ b/config/webpush.php
@@ -34,6 +34,11 @@ return [
      * The Guzzle client options used by Minishlink\WebPush.
      */
     'client_options' => [],
+    
+    /**
+     * The automatic padding in bytes used by Minishlink\WebPush.
+     */
+    'automatic_padding' => 4078,
 
     /**
      * Google Cloud Messaging.

--- a/config/webpush.php
+++ b/config/webpush.php
@@ -39,7 +39,7 @@ return [
      * The automatic padding in bytes used by Minishlink\WebPush.
      * Set to false to support Firefox Android with v1 endpoint 
      */
-    'automatic_padding' => 4078,
+    'automatic_padding' => 3052,
 
     /**
      * Google Cloud Messaging.

--- a/config/webpush.php
+++ b/config/webpush.php
@@ -37,6 +37,7 @@ return [
     
     /**
      * The automatic padding in bytes used by Minishlink\WebPush.
+     * Set to false to support Firefox Android with v1 endpoint 
      */
     'automatic_padding' => 4078,
 

--- a/src/WebPushServiceProvider.php
+++ b/src/WebPushServiceProvider.php
@@ -5,7 +5,6 @@ namespace NotificationChannels\WebPush;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Minishlink\WebPush\WebPush;
-use Minishlink\WebPush\Encryption;
 
 class WebPushServiceProvider extends ServiceProvider
 {
@@ -28,10 +27,10 @@ class WebPushServiceProvider extends ServiceProvider
             ->needs(WebPush::class)
             ->give(function () {
                 return (new WebPush(
-                        $this->webPushAuth(), [], 30, config('webpush.client_options', [])
-                    ))
+                    $this->webPushAuth(), [], 30, config('webpush.client_options', [])
+                ))
                     ->setReuseVAPIDHeaders(true)
-                    ->setAutomaticPadding(config('webpush.automatic_padding', Encryption::MAX_COMPATIBILITY_PAYLOAD_LENGTH));
+                    ->setAutomaticPadding(config('webpush.automatic_padding'));
             });
 
         $this->app->when(WebPushChannel::class)

--- a/src/WebPushServiceProvider.php
+++ b/src/WebPushServiceProvider.php
@@ -31,8 +31,10 @@ class WebPushServiceProvider extends ServiceProvider
             ->needs(WebPush::class)
             ->give(function () {
                 return (new WebPush(
-                    $this->webPushAuth(), [], 30, config('webpush.client_options', [])
-                ))->setReuseVAPIDHeaders(true);
+                        $this->webPushAuth(), [], 30, config('webpush.client_options', [])
+                    ))
+                    ->setReuseVAPIDHeaders(true)
+                    ->setAutomaticPadding(config('webpush.automatic_padding', 4078));
             });
 
         $this->app->when(WebPushChannel::class)

--- a/src/WebPushServiceProvider.php
+++ b/src/WebPushServiceProvider.php
@@ -5,6 +5,7 @@ namespace NotificationChannels\WebPush;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Minishlink\WebPush\WebPush;
+use Minishlink\WebPush\Encryption;
 
 class WebPushServiceProvider extends ServiceProvider
 {
@@ -34,7 +35,7 @@ class WebPushServiceProvider extends ServiceProvider
                         $this->webPushAuth(), [], 30, config('webpush.client_options', [])
                     ))
                     ->setReuseVAPIDHeaders(true)
-                    ->setAutomaticPadding(config('webpush.automatic_padding', 3052));
+                    ->setAutomaticPadding(config('webpush.automatic_padding', Encryption::MAX_COMPATIBILITY_PAYLOAD_LENGTH));
             });
 
         $this->app->when(WebPushChannel::class)

--- a/src/WebPushServiceProvider.php
+++ b/src/WebPushServiceProvider.php
@@ -34,7 +34,7 @@ class WebPushServiceProvider extends ServiceProvider
                         $this->webPushAuth(), [], 30, config('webpush.client_options', [])
                     ))
                     ->setReuseVAPIDHeaders(true)
-                    ->setAutomaticPadding(config('webpush.automatic_padding', 4078));
+                    ->setAutomaticPadding(config('webpush.automatic_padding', 3052));
             });
 
         $this->app->when(WebPushChannel::class)


### PR DESCRIPTION
To support Firefox Android, automatic padding applied by WebPush has to be disabled: https://github.com/web-push-libs/web-push-php#how-can-i-disable-or-customize-automatic-padding

This PR just applies the default 3052 bytes but you can set `automatic_padding` to false to support Firefox Android

Fix for https://github.com/laravel-notification-channels/webpush/issues/103#issuecomment-1205132556