### PR TITLE
chore: update to web-push v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^8.0",
         "illuminate/notifications": "^8.0|^9.0",
         "illuminate/support": "^8.0|^9.0",
-        "minishlink/web-push": "^7.0"
+        "minishlink/web-push": "^8.0"
     },
     "require-dev": {
         "mockery/mockery": "~1.0",


### PR DESCRIPTION
This will update web-push to v8. The only breaking change is the drop of PHP 7.4 as supported version. As this module already requires PHP 8.0 or higher, this should have no impact.