### PR TITLE
chore: support Laravel 10.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,14 +11,19 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.0]
+        php: [8.2, 8.1, 8.0]
         laravel: [9.*, 8.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 10.*
+            testbench: 8.*
+            php: [8.1, 8.2]
           - laravel: 9.*
             testbench: 7.*
+            php: [8.0, 8.1, 8.2]
           - laravel: 8.*
             testbench: ^6.23
+            php: [8.0, 8.1]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,9 +41,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.testbench }}-composer
           restore-keys: |
-            ${{ runner.os }}-P${{ matrix.php }}-L${{ matrix.laravel }}-composer-
+            ${{ runner.os }}-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.testbench }}-composer
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,13 @@ jobs:
         php: [8.2, 8.1, 8.0]
         laravel: [10.*, 9.*, 8.*]
         stability: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 10.*
+            testbench: 8.*
+          - laravel: 9.*
+            testbench: 7.*
+          - laravel: 8.*
+            testbench: ^6.23
         exclude:
           - laravel: 10.*
             php: 8.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,14 @@ jobs:
           - laravel: 8.*
             testbench: ^6.23
         exclude:
+          # Laravel 10 doesn't support PHP 8.0
           - laravel: 10.*
             php: 8.0
+          # Laravel 9 on PHP 8.2 has problems with mistagged dependencies on prefer-lowest
+          - laravel: 9.*
+            php: 8.2
+            stability: prefer-lowest
+          # Laravel 8 doesn't support PHP 8.2
           - laravel: 8.*
             php: 8.2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,14 +31,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get Composer cache directory
         id: composer-cache
         run: |
           echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,17 +18,13 @@ jobs:
           - laravel: 10.*
             testbench: 8.*
           - laravel: 9.*
-            testbench: 7.*
+            testbench: ^7.19
           - laravel: 8.*
             testbench: ^6.23
         exclude:
           # Laravel 10 doesn't support PHP 8.0
           - laravel: 10.*
             php: 8.0
-          # Laravel 9 on PHP 8.2 has problems with mistagged dependencies on prefer-lowest
-          - laravel: 9.*
-            php: 8.2
-            stability: prefer-lowest
           # Laravel 8 doesn't support PHP 8.2
           - laravel: 8.*
             php: 8.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           - laravel: 8.*
             php: 8.2
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,9 +41,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.testbench }}-composer
+          key: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.testbench }}-${{ matrix.stability }}-composer
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.testbench }}-composer
+            ${{ runner.os }}-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.testbench }}-${{ matrix.stability }}-composer
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,18 +12,13 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.1, 8.0]
-        laravel: [9.*, 8.*]
+        laravel: [10.*, 9.*, 8.*]
         stability: [prefer-lowest, prefer-stable]
-        include:
+        exclude:
           - laravel: 10.*
-            testbench: 8.*
-            php: [8.1, 8.2]
-          - laravel: 9.*
-            testbench: 7.*
-            php: [8.0, 8.1, 8.2]
+            php: 8.0
           - laravel: 8.*
-            testbench: ^6.23
-            php: [8.0, 8.1]
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/notifications": "^8.0|^9.0",
-        "illuminate/support": "^8.0|^9.0",
+        "illuminate/notifications": "^8.0|^9.0|^10.0",
+        "illuminate/support": "^8.0|^9.0|^10.0",
         "minishlink/web-push": "^7.0"
     },
     "require-dev": {
         "mockery/mockery": "~1.0",
-        "orchestra/testbench": "^6.0|^7.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0",
         "phpunit/phpunit": "^9.0"
     },
     "autoload": {


### PR DESCRIPTION
This PR adds support for Laravel 10.x which will be released half February. It runs tests against PHP 8.0-8.2 for Laravel 8.x-10.x. I also updated the Github Actions dependencies to avoid some warnings and I fixed the cache keys.