### PR TITLE
Update README.md for iOS Web Push and VAPID credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ php artisan webpush:vapid
 
 This command will set `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY`in your `.env` file.
 
+> Note: if targeting Safari or iOS after 2023, you will need to include the `VAPID_SUBJECT` variable as well or Apple will return a `BadJwtToken` error.
+
 __These keys must be safely stored and should not change.__
 
 If you still want support for [Google Cloud Messaging](https://console.cloud.google.com), set the `GCM_KEY` and `GCM_SENDER_ID` in your `.env` file.


### PR DESCRIPTION
Since Apple added web push support to iOS in 2023, there hasn't been a lot of details around what exactly is required.

Following the readme in this project, push notifications were working for Chromium browsers.

Apple follows a part of the spec that requires a VAPID subject to generate the push JWT. I found this specific information through a Java based library elsewhere on Github. https://github.com/web-push-libs/webpush-java/issues/201#issuecomment-1443258546

Adding this information should make things a lot clearer for people trying to add native web push support to their web apps moving forward.