### PR TITLE
chore: allow laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: curl
-          coverage: none
+          coverage: xdebug
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Get Composer cache directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,36 +11,36 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.1, 8.0]
-        laravel: [9.*, 8.*, 10.*]
+        php: [8.3, 8.2, 8.1]
+        laravel: [9.*, 10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 11.*
+            testbench: 9.*
           - laravel: 10.*
             testbench: 8.*
           - laravel: 9.*
             testbench: ^7.19
-          - laravel: 8.*
-            testbench: ^6.23
         exclude:
-          # Laravel 10 doesn't support PHP 8.0
+          # Laravel 11 doesn't support PHP 8.1
+          - laravel: 11.*
+            php: 8.1
+          # Laravel 9 doesn't support PHP 8.3
           - laravel: 10.*
-            php: 8.0
-          # Laravel 8 doesn't support PHP 8.2
-          - laravel: 8.*
-            php: 8.2
+            php: 8.3
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get Composer cache directory
         id: composer-cache
         run: |
           echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.testbench }}-${{ matrix.stability }}-composer

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/notifications": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0",
+        "php": "^8.1",
+        "illuminate/notifications": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^9.0|^10.0|^11.0",
         "minishlink/web-push": "^8.0"
     },
     "require-dev": {
         "mockery/mockery": "~1.0",
-        "orchestra/testbench": "^6.0|^7.0|^8.0",
-        "phpunit/phpunit": "^9.0"
+        "orchestra/testbench": "^7.0|^8.0|^9.0",
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "mockery/mockery": "~1.0",
         "orchestra/testbench": "^7.0|^8.0|^9.0",
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^9.5|^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
     <report>
       <clover outputFile="build/logs/clover.xml"/>
       <html outputDirectory="build/coverage"/>
@@ -22,4 +19,9 @@
     <env name="DB_CONNECTION" value="sqlite"/>
     <env name="DB_DATABASE" value=":memory:"/>
   </php>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
This PR adds support for Laravel 11. It drops support for Laravel 8 and PHP 8.0 as both are EOL (Laravel 9 is also EOL, so we may want to drop that as well?). The underlying `minishlink/web-push` will also drop PHP 8.0 in it's next major release.

Further, it runs tests on PHPunit 10 and there are some updates to the Github Action workflows.