### PR TITLE
Updated minislink/web-push

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,11 @@
 {
-    "name": "laravel-notification-channels/webpush",
+    "name":"carloeusebi/webpush",
     "description": "Web Push Notifications driver for Laravel.",
-    "homepage": "https://github.com/laravel-notification-channels/webpush",
+    "homepage": "https://github.com/carloeusebi/webpush",
     "license": "MIT",
     "authors": [
         {
-            "name": "Cretu Eusebiu",
-            "email": "me@cretueusebiu.com",
-            "homepage": "http://cretueusebiu.com",
+            "name": "Carlo Eusebi",
             "role": "Developer"
         }
     ],

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^8.1",
         "illuminate/notifications": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0",
-        "minishlink/web-push": "^8.0"
+        "minishlink/web-push": "v9.0.0-rc2"
     },
     "require-dev": {
         "mockery/mockery": "~1.0",


### PR DESCRIPTION
Updated minishlink/webpush requirements to newest release candidate version because older version was using abandoned packages.

See issue #201 