### PR TITLE
chore: bump web-push library to v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^8.1",
         "illuminate/notifications": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0",
-        "minishlink/web-push": "^8.0"
+        "minishlink/web-push": "^9.0"
     },
     "require-dev": {
         "mockery/mockery": "~1.0",


### PR DESCRIPTION
It bumps the web-push library to v9. There are several breaking changes, not impacting code in this repository but might break specific implementations. It's wise to release this one in a major version.