### PR TITLE
refactor: use native types

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
-            testbench: 9.*
+            testbench: ^9.2
           - laravel: 12.*
             testbench: 10.*
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.phar
 composer.lock
 .phpunit.result.cache
 .phpunit.cache
+.phpstan.cache

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,12 @@
         "minishlink/web-push": "^9.0"
     },
     "require-dev": {
+        "laravel/pint": "^1.21",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^9.0|^10.0",
-        "phpunit/phpunit": "^10.5|^11.5.3"
+        "larastan/larastan": "^3.1",
+        "phpunit/phpunit": "^10.5|^11.5.3",
+        "rector/rector": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "laravel/pint": "^1.21",
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^9.0|^10.0",
+        "orchestra/testbench": "^9.2|^10.0",
         "larastan/larastan": "^3.1",
         "phpunit/phpunit": "^10.5|^11.5.3",
         "rector/rector": "^2.0"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,13 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Method NotificationChannels\\WebPush\\PushSubscription\:\:findByEndpoint\(\) should return static\(NotificationChannels\\WebPush\\PushSubscription\)\|null but returns NotificationChannels\\WebPush\\PushSubscription\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: src/PushSubscription.php
+
+		-
+			message: '#^Method NotificationChannels\\WebPush\\Test\\User\:\:pushSubscriptions\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphMany\<NotificationChannels\\WebPush\\PushSubscription, \$this\(NotificationChannels\\WebPush\\Test\\User\)\> but returns Illuminate\\Database\\Eloquent\\Relations\\MorphMany\<Illuminate\\Database\\Eloquent\\Model, \$this\(NotificationChannels\\WebPush\\Test\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: tests/User.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,3 +11,9 @@ parameters:
 			identifier: return.type
 			count: 1
 			path: tests/User.php
+
+		-
+			message: '#^Unable to resolve the template type TRelatedModel in call to method Illuminate\\Database\\Eloquent\\Model\:\:morphMany\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: tests/User.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,6 +9,6 @@ parameters:
         - tests
         - migrations/create_push_subscriptions_table.php.stub
 
-    level: 5
+    level: 6
 
     tmpDir: .phpstan.cache

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,14 @@
+includes:
+    - ./vendor/larastan/larastan/extension.neon
+    - ./phpstan-baseline.neon
+
+parameters:
+
+    paths:
+        - src
+        - tests
+        - migrations/create_push_subscriptions_table.php.stub
+
+    level: 5
+
+    tmpDir: .phpstan.cache

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,16 @@
+<?php
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__.'/src',
+        __DIR__.'/tests',
+    ])
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        codingStyle: true,
+        typeDeclarations: true,
+    )
+    ->withPhpSets(php82: true);

--- a/src/Events/NotificationFailed.php
+++ b/src/Events/NotificationFailed.php
@@ -16,5 +16,8 @@ class NotificationFailed
      *
      * @return void
      */
-    public function __construct(public MessageSentReport $report, public PushSubscription $subscription, public WebPushMessage $message) {}
+    public function __construct(public MessageSentReport $report, public PushSubscription $subscription, public WebPushMessage $message)
+    {
+        //
+    }
 }

--- a/src/Events/NotificationFailed.php
+++ b/src/Events/NotificationFailed.php
@@ -3,38 +3,18 @@
 namespace NotificationChannels\WebPush\Events;
 
 use Illuminate\Queue\SerializesModels;
+use Minishlink\WebPush\MessageSentReport;
+use NotificationChannels\WebPush\PushSubscription;
+use NotificationChannels\WebPush\WebPushMessage;
 
 class NotificationFailed
 {
     use SerializesModels;
 
     /**
-     * @var \Minishlink\WebPush\MessageSentReport
-     */
-    public $report;
-
-    /**
-     * @var \NotificationChannels\WebPush\PushSubscription
-     */
-    public $subscription;
-
-    /**
-     * @var \NotificationChannels\WebPush\WebPushMessage
-     */
-    public $message;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Minishlink\WebPush\MessageSentReport  $report
-     * @param  \NotificationChannels\WebPush\PushSubscription  $subscription
-     * @param  \NotificationChannels\WebPush\WebPushMessage  $message
      * @return void
      */
-    public function __construct($report, $subscription, $message)
-    {
-        $this->report = $report;
-        $this->subscription = $subscription;
-        $this->message = $message;
-    }
+    public function __construct(public MessageSentReport $report, public PushSubscription $subscription, public WebPushMessage $message) {}
 }

--- a/src/Events/NotificationSent.php
+++ b/src/Events/NotificationSent.php
@@ -3,38 +3,18 @@
 namespace NotificationChannels\WebPush\Events;
 
 use Illuminate\Queue\SerializesModels;
+use Minishlink\WebPush\MessageSentReport;
+use NotificationChannels\WebPush\PushSubscription;
+use NotificationChannels\WebPush\WebPushMessage;
 
 class NotificationSent
 {
     use SerializesModels;
 
     /**
-     * @var \Minishlink\WebPush\MessageSentReport
-     */
-    public $report;
-
-    /**
-     * @var \NotificationChannels\WebPush\PushSubscription
-     */
-    public $subscription;
-
-    /**
-     * @var \NotificationChannels\WebPush\WebPushMessage
-     */
-    public $message;
-
-    /**
      * Create a new event instance.
      *
-     * @param  \Minishlink\WebPush\MessageSentReport  $report
-     * @param  \NotificationChannels\WebPush\PushSubscription  $subscription
-     * @param  \NotificationChannels\WebPush\WebPushMessage  $message
      * @return void
      */
-    public function __construct($report, $subscription, $message)
-    {
-        $this->report = $report;
-        $this->subscription = $subscription;
-        $this->message = $message;
-    }
+    public function __construct(public MessageSentReport $report, public PushSubscription $subscription, public WebPushMessage $message) {}
 }

--- a/src/Events/NotificationSent.php
+++ b/src/Events/NotificationSent.php
@@ -16,5 +16,8 @@ class NotificationSent
      *
      * @return void
      */
-    public function __construct(public MessageSentReport $report, public PushSubscription $subscription, public WebPushMessage $message) {}
+    public function __construct(public MessageSentReport $report, public PushSubscription $subscription, public WebPushMessage $message)
+    {
+        //
+    }
 }

--- a/src/HasPushSubscriptions.php
+++ b/src/HasPushSubscriptions.php
@@ -67,7 +67,7 @@ trait HasPushSubscriptions
     /**
      * Get all of the subscriptions.
      *
-     * @return \Illuminate\Database\Eloquent\Collection<\NotificationChannels\WebPush\PushSubscription>
+     * @return \Illuminate\Database\Eloquent\Collection<array-key, \NotificationChannels\WebPush\PushSubscription>
      */
     public function routeNotificationForWebPush(): Collection
     {

--- a/src/HasPushSubscriptions.php
+++ b/src/HasPushSubscriptions.php
@@ -2,28 +2,25 @@
 
 namespace NotificationChannels\WebPush;
 
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
 trait HasPushSubscriptions
 {
     /**
      *  Get all of the subscriptions.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<PushSubscription, $this>
      */
-    public function pushSubscriptions()
+    public function pushSubscriptions(): MorphMany
     {
         return $this->morphMany(config('webpush.model'), 'subscribable');
     }
 
     /**
      * Update (or create) subscription.
-     *
-     * @param  string  $endpoint
-     * @param  string|null  $key
-     * @param  string|null  $token
-     * @param  string|null  $contentEncoding
-     * @return \NotificationChannels\WebPush\PushSubscription
      */
-    public function updatePushSubscription($endpoint, $key = null, $token = null, $contentEncoding = null)
+    public function updatePushSubscription(string $endpoint, ?string $key = null, ?string $token = null, ?string $contentEncoding = null): PushSubscription
     {
         $subscription = app(config('webpush.model'))->findByEndpoint($endpoint);
 
@@ -50,11 +47,8 @@ trait HasPushSubscriptions
 
     /**
      * Determine if the model owns the given subscription.
-     *
-     * @param  \NotificationChannels\WebPush\PushSubscription  $subscription
-     * @return bool
      */
-    public function ownsPushSubscription($subscription)
+    public function ownsPushSubscription(PushSubscription $subscription): bool
     {
         return (string) $subscription->subscribable_id === (string) $this->getKey() &&
                         $subscription->subscribable_type === $this->getMorphClass();
@@ -62,11 +56,8 @@ trait HasPushSubscriptions
 
     /**
      * Delete subscription by endpoint.
-     *
-     * @param  string  $endpoint
-     * @return void
      */
-    public function deletePushSubscription($endpoint)
+    public function deletePushSubscription(string $endpoint): void
     {
         $this->pushSubscriptions()
             ->where('endpoint', $endpoint)
@@ -76,9 +67,9 @@ trait HasPushSubscriptions
     /**
      * Get all of the subscriptions.
      *
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<\NotificationChannels\WebPush\PushSubscription>
      */
-    public function routeNotificationForWebPush()
+    public function routeNotificationForWebPush(): Collection
     {
         return $this->pushSubscriptions;
     }

--- a/src/PushSubscription.php
+++ b/src/PushSubscription.php
@@ -3,20 +3,20 @@
 namespace NotificationChannels\WebPush;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 /**
+ * @property int|string $subscribable_id
+ * @property class-string $subscribable_type
  * @property string $endpoint
  * @property string|null $public_key
  * @property string|null $auth_token
  * @property string|null $content_encoding
- * @property \Illuminate\Database\Eloquent\Model $subscribable
  */
 class PushSubscription extends Model
 {
     /**
      * The attributes that are mass assignable.
-     *
-     * @var array
      */
     protected $fillable = [
         'endpoint',
@@ -28,16 +28,15 @@ class PushSubscription extends Model
     /**
      * Create a new model instance.
      *
-     * @param  array  $attributes
      * @return void
      */
     public function __construct(array $attributes = [])
     {
-        if (! isset($this->connection)) {
+        if ($this->connection === null) {
             $this->setConnection(config('webpush.database_connection'));
         }
 
-        if (! isset($this->table)) {
+        if ($this->table === null) {
             $this->setTable(config('webpush.table_name'));
         }
 
@@ -46,22 +45,17 @@ class PushSubscription extends Model
 
     /**
      * Get the model related to the subscription.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function subscribable()
+    public function subscribable(): MorphTo
     {
         return $this->morphTo();
     }
 
     /**
-     * Find a subscription by the given endpint.
-     *
-     * @param  string  $endpoint
-     * @return static|null
+     * Find a subscription by the given endpoint.
      */
-    public static function findByEndpoint($endpoint)
+    public static function findByEndpoint(string $endpoint): ?static
     {
-        return static::where('endpoint', $endpoint)->first();
+        return static::firstWhere('endpoint', $endpoint);
     }
 }

--- a/src/PushSubscription.php
+++ b/src/PushSubscription.php
@@ -28,6 +28,7 @@ class PushSubscription extends Model
     /**
      * Create a new model instance.
      *
+     * @param  array<string, mixed>  $attributes
      * @return void
      */
     public function __construct(array $attributes = [])
@@ -45,6 +46,8 @@ class PushSubscription extends Model
 
     /**
      * Get the model related to the subscription.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo<\Illuminate\Database\Eloquent\Model, $this>
      */
     public function subscribable(): MorphTo
     {

--- a/src/ReportHandler.php
+++ b/src/ReportHandler.php
@@ -13,7 +13,10 @@ class ReportHandler implements ReportHandlerInterface
      *
      * @return void
      */
-    public function __construct(protected \Illuminate\Contracts\Events\Dispatcher $events) {}
+    public function __construct(protected \Illuminate\Contracts\Events\Dispatcher $events)
+    {
+        //
+    }
 
     /**
      * Handle a message sent report.

--- a/src/ReportHandler.php
+++ b/src/ReportHandler.php
@@ -2,37 +2,23 @@
 
 namespace NotificationChannels\WebPush;
 
-use Illuminate\Contracts\Events\Dispatcher;
+use Minishlink\WebPush\MessageSentReport;
 use NotificationChannels\WebPush\Events\NotificationFailed;
 use NotificationChannels\WebPush\Events\NotificationSent;
 
 class ReportHandler implements ReportHandlerInterface
 {
     /**
-     * @var \Illuminate\Contracts\Events\Dispatcher
-     */
-    protected $events;
-
-    /**
      * Create a new report handler.
      *
-     * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @return void
      */
-    public function __construct(Dispatcher $events)
-    {
-        $this->events = $events;
-    }
+    public function __construct(protected \Illuminate\Contracts\Events\Dispatcher $events) {}
 
     /**
      * Handle a message sent report.
-     *
-     * @param  \Minishlink\WebPush\MessageSentReport  $report
-     * @param  \NotificationChannels\WebPush\PushSubscription  $subscription
-     * @param  \NotificationChannels\WebPush\WebPushMessage  $message
-     * @return void
      */
-    public function handleReport($report, $subscription, $message)
+    public function handleReport(MessageSentReport $report, PushSubscription $subscription, WebPushMessage $message): void
     {
         if ($report->isSuccess()) {
             $this->events->dispatch(new NotificationSent($report, $subscription, $message));

--- a/src/ReportHandlerInterface.php
+++ b/src/ReportHandlerInterface.php
@@ -2,15 +2,12 @@
 
 namespace NotificationChannels\WebPush;
 
+use Minishlink\WebPush\MessageSentReport;
+
 interface ReportHandlerInterface
 {
     /**
      * Handle a message sent report.
-     *
-     * @param  \Minishlink\WebPush\MessageSentReport  $report
-     * @param  \NotificationChannels\WebPush\PushSubscription  $subscription
-     * @param  \NotificationChannels\WebPush\WebPushMessage  $message
-     * @return void
      */
-    public function handleReport($report, $subscription, $message);
+    public function handleReport(MessageSentReport $report, PushSubscription $subscription, WebPushMessage $message): void;
 }

--- a/src/VapidKeysGenerateCommand.php
+++ b/src/VapidKeysGenerateCommand.php
@@ -25,10 +25,8 @@ class VapidKeysGenerateCommand extends Command
 
     /**
      * Execute the console command.
-     *
-     * @return mixed
      */
-    public function handle()
+    public function handle(): void
     {
         $keys = VAPID::createVapidKeys();
 
@@ -48,15 +46,12 @@ class VapidKeysGenerateCommand extends Command
 
     /**
      * Set the keys in the environment file.
-     *
-     * @param  array  $keys
-     * @return bool
      */
-    protected function setKeysInEnvironmentFile($keys)
+    protected function setKeysInEnvironmentFile(array $keys): bool
     {
         $currentKeys = $this->laravel['config']['webpush.vapid'];
 
-        if (strlen($currentKeys['public_key']) !== 0 && (! $this->confirmToProceed())) {
+        if (strlen((string) $currentKeys['public_key']) !== 0 && (! $this->confirmToProceed())) {
             return false;
         }
 
@@ -67,11 +62,8 @@ class VapidKeysGenerateCommand extends Command
 
     /**
      * Write a new environment file with the given keys.
-     *
-     * @param  array  $keys
-     * @return void
      */
-    protected function writeNewEnvironmentFileWith($keys)
+    protected function writeNewEnvironmentFileWith(array $keys): void
     {
         $contents = file_get_contents($this->laravel->environmentFilePath());
 
@@ -100,22 +92,15 @@ class VapidKeysGenerateCommand extends Command
 
     /**
      * Get a regex pattern that will match env $keyName with any key.
-     *
-     * @param  string  $keyName
-     * @return string
      */
-    protected function keyReplacementPattern($keyName)
+    protected function keyReplacementPattern(string $keyName): string
     {
         $key = $this->laravel['config']['webpush.vapid'];
 
-        if ($keyName === 'VAPID_PUBLIC_KEY') {
-            $key = $key['public_key'];
-        } else {
-            $key = $key['private_key'];
-        }
+        $key = $keyName === 'VAPID_PUBLIC_KEY' ? $key['public_key'] : $key['private_key'];
 
         $escaped = preg_quote('='.$key, '/');
 
-        return "/^{$keyName}{$escaped}/m";
+        return sprintf('/^%s%s/m', $keyName, $escaped);
     }
 }

--- a/src/VapidKeysGenerateCommand.php
+++ b/src/VapidKeysGenerateCommand.php
@@ -46,6 +46,8 @@ class VapidKeysGenerateCommand extends Command
 
     /**
      * Set the keys in the environment file.
+     *
+     * @param  array{'publicKey': string, 'privateKey': string}  $keys
      */
     protected function setKeysInEnvironmentFile(array $keys): bool
     {
@@ -62,6 +64,8 @@ class VapidKeysGenerateCommand extends Command
 
     /**
      * Write a new environment file with the given keys.
+     *
+     * @param  array{'publicKey': string, 'privateKey': string}  $keys
      */
     protected function writeNewEnvironmentFileWith(array $keys): void
     {

--- a/src/WebPushChannel.php
+++ b/src/WebPushChannel.php
@@ -14,14 +14,17 @@ class WebPushChannel
     /**
      * @return void
      */
-    public function __construct(protected WebPush $webPush, protected ReportHandlerInterface $reportHandler) {}
+    public function __construct(protected WebPush $webPush, protected ReportHandlerInterface $reportHandler)
+    {
+        //
+    }
 
     /**
      * Send the given notification.
      */
     public function send(mixed $notifiable, Notification $notification): void
     {
-        /** @var \Illuminate\Database\Eloquent\Collection $subscriptions */
+        /** @var \Illuminate\Database\Eloquent\Collection<array-key, PushSubscription> $subscriptions */
         $subscriptions = $notifiable->routeNotificationFor('WebPush', $notification);
 
         if ($subscriptions->isEmpty()) {

--- a/src/WebPushMessage.php
+++ b/src/WebPushMessage.php
@@ -2,12 +2,15 @@
 
 namespace NotificationChannels\WebPush;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 
 /**
+ * @implements \Illuminate\Contracts\Support\Arrayable<string, mixed>
+ * 
  * @link https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification#Parameters
  */
-class WebPushMessage
+class WebPushMessage implements Arrayable
 {
     protected string $title;
 

--- a/src/WebPushMessage.php
+++ b/src/WebPushMessage.php
@@ -11,6 +11,9 @@ class WebPushMessage
 {
     protected string $title;
 
+    /**
+     * @var array<array-key, array{'title': string, 'action': string, 'icon'?: string}>
+     */
     protected array $actions = [];
 
     protected string $badge;
@@ -31,10 +34,16 @@ class WebPushMessage
 
     protected string $tag;
 
+    /**
+     * @var array<int>
+     */
     protected array $vibrate;
 
     protected mixed $data;
 
+    /**
+     * @var array<string, mixed>
+     */
     protected array $options = [];
 
     /**
@@ -168,6 +177,7 @@ class WebPushMessage
     /**
      * Set the notification vibration pattern.
      *
+     * @param  array<int>  $value
      * @return $this
      */
     public function vibrate(array $value): static
@@ -194,6 +204,7 @@ class WebPushMessage
      *
      * @link https://github.com/web-push-libs/web-push-php#notifications-and-default-options
      *
+     * @param  array<string, mixed>  $value
      * @return $this
      */
     public function options(array $value): static
@@ -205,6 +216,8 @@ class WebPushMessage
 
     /**
      * Get the notification options.
+     *
+     * @return array<string, mixed>
      */
     public function getOptions(): array
     {
@@ -213,6 +226,8 @@ class WebPushMessage
 
     /**
      * Get an array representation of the message.
+     *
+     * @return array<string, mixed>
      */
     public function toArray(): array
     {

--- a/src/WebPushMessage.php
+++ b/src/WebPushMessage.php
@@ -9,83 +9,40 @@ use Illuminate\Support\Arr;
  */
 class WebPushMessage
 {
-    /**
-     * @var string
-     */
-    protected $title;
+    protected string $title;
 
-    /**
-     * @var array
-     */
-    protected $actions = [];
+    protected array $actions = [];
 
-    /**
-     * @var string
-     */
-    protected $badge;
+    protected string $badge;
 
-    /**
-     * @var string
-     */
-    protected $body;
+    protected string $body;
 
-    /**
-     * @var string
-     */
-    protected $dir;
+    protected string $dir;
 
-    /**
-     * @var string
-     */
-    protected $icon;
+    protected string $icon;
 
-    /**
-     * @var string
-     */
-    protected $image;
+    protected string $image;
 
-    /**
-     * @var string
-     */
-    protected $lang;
+    protected string $lang;
 
-    /**
-     * @var bool
-     */
-    protected $renotify;
+    protected bool $renotify;
 
-    /**
-     * @var bool
-     */
-    protected $requireInteraction;
+    protected bool $requireInteraction;
 
-    /**
-     * @var string
-     */
-    protected $tag;
+    protected string $tag;
 
-    /**
-     * @var array
-     */
-    protected $vibrate;
+    protected array $vibrate;
 
-    /**
-     * @var mixed
-     */
-    protected $data;
+    protected mixed $data;
 
-    /**
-     * @var array
-     */
-    protected $options = [];
+    protected array $options = [];
 
     /**
      * Set the notification title.
      *
-     * @param  string  $value
      * @return $this
      */
-    public function title($value)
+    public function title(string $value): static
     {
         $this->title = $value;
 
@@ -95,14 +52,11 @@ class WebPushMessage
     /**
      * Add a notification action.
      *
-     * @param  string  $title
-     * @param  string  $action
-     * @param  string  $icon
      * @return $this
      */
-    public function action($title, $action, $icon = null)
+    public function action(string $title, string $action, ?string $icon = null): static
     {
-        $this->actions[] = array_filter(compact('title', 'action', 'icon'));
+        $this->actions[] = array_filter(['title' => $title, 'action' => $action, 'icon' => $icon]);
 
         return $this;
     }
@@ -110,10 +64,9 @@ class WebPushMessage
     /**
      * Set the notification badge.
      *
-     * @param  string  $value
      * @return $this
      */
-    public function badge($value)
+    public function badge(string $value): static
     {
         $this->badge = $value;
 
@@ -123,10 +76,9 @@ class WebPushMessage
     /**
      * Set the notification body.
      *
-     * @param  string  $value
      * @return $this
      */
-    public function body($value)
+    public function body(string $value): static
     {
         $this->body = $value;
 
@@ -136,10 +88,9 @@ class WebPushMessage
     /**
      * Set the notification direction.
      *
-     * @param  string  $value
      * @return $this
      */
-    public function dir($value)
+    public function dir(string $value): static
     {
         $this->dir = $value;
 
@@ -149,10 +100,9 @@ class WebPushMessage
     /**
      * Set the notification icon url.
      *
-     * @param  string  $value
      * @return $this
      */
-    public function icon($value)
+    public function icon(string $value): static
     {
         $this->icon = $value;
 
@@ -162,10 +112,9 @@ class WebPushMessage
     /**
      * Set the notification image url.
      *
-     * @param  string  $value
      * @return $this
      */
-    public function image($value)
+    public function image(string $value): static
     {
         $this->image = $value;
 
@@ -175,10 +124,9 @@ class WebPushMessage
     /**
      * Set the notification language.
      *
-     * @param  string  $value
      * @return $this
      */
-    public function lang($value)
+    public function lang(string $value): static
     {
         $this->lang = $value;
 
@@ -186,10 +134,9 @@ class WebPushMessage
     }
 
     /**
-     * @param  bool  $value
      * @return $this
      */
-    public function renotify($value = true)
+    public function renotify(bool $value = true): static
     {
         $this->renotify = $value;
 
@@ -197,10 +144,9 @@ class WebPushMessage
     }
 
     /**
-     * @param  bool  $value
      * @return $this
      */
-    public function requireInteraction($value = true)
+    public function requireInteraction(bool $value = true): static
     {
         $this->requireInteraction = $value;
 
@@ -210,10 +156,9 @@ class WebPushMessage
     /**
      * Set the notification tag.
      *
-     * @param  string  $value
      * @return $this
      */
-    public function tag($value)
+    public function tag(string $value): static
     {
         $this->tag = $value;
 
@@ -223,10 +168,9 @@ class WebPushMessage
     /**
      * Set the notification vibration pattern.
      *
-     * @param  array  $value
      * @return $this
      */
-    public function vibrate($value)
+    public function vibrate(array $value): static
     {
         $this->vibrate = $value;
 
@@ -236,10 +180,9 @@ class WebPushMessage
     /**
      * Set the notification arbitrary data.
      *
-     * @param  mixed  $value
      * @return $this
      */
-    public function data($value)
+    public function data(mixed $value): static
     {
         $this->data = $value;
 
@@ -251,10 +194,9 @@ class WebPushMessage
      *
      * @link https://github.com/web-push-libs/web-push-php#notifications-and-default-options
      *
-     * @param  array  $value
      * @return $this
      */
-    public function options(array $value)
+    public function options(array $value): static
     {
         $this->options = $value;
 
@@ -263,20 +205,16 @@ class WebPushMessage
 
     /**
      * Get the notification options.
-     *
-     * @return array
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }
 
     /**
      * Get an array representation of the message.
-     *
-     * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return Arr::except(array_filter(get_object_vars($this)), ['options']);
     }

--- a/src/WebPushMessage.php
+++ b/src/WebPushMessage.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Arr;
 
 /**
  * @implements \Illuminate\Contracts\Support\Arrayable<string, mixed>
- * 
+ *
  * @link https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification#Parameters
  */
 class WebPushMessage implements Arrayable

--- a/src/WebPushServiceProvider.php
+++ b/src/WebPushServiceProvider.php
@@ -40,6 +40,8 @@ class WebPushServiceProvider extends ServiceProvider
 
     /**
      * Get the authentication details.
+     *
+     * @return array<string, mixed>
      */
     protected function webPushAuth(): array
     {

--- a/src/WebPushServiceProvider.php
+++ b/src/WebPushServiceProvider.php
@@ -10,10 +10,8 @@ class WebPushServiceProvider extends ServiceProvider
 {
     /**
      * Register the application services.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->commands([VapidKeysGenerateCommand::class]);
 
@@ -22,18 +20,14 @@ class WebPushServiceProvider extends ServiceProvider
 
     /**
      * Bootstrap the application services.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->app->when(WebPushChannel::class)
             ->needs(WebPush::class)
-            ->give(function () {
-                return (new WebPush(
-                    $this->webPushAuth(), [], 30, config('webpush.client_options', [])
-                ))->setReuseVAPIDHeaders(true);
-            });
+            ->give(fn (): WebPush => (new WebPush(
+                $this->webPushAuth(), [], 30, config('webpush.client_options', [])
+            ))->setReuseVAPIDHeaders(true));
 
         $this->app->when(WebPushChannel::class)
             ->needs(ReportHandlerInterface::class)
@@ -46,10 +40,8 @@ class WebPushServiceProvider extends ServiceProvider
 
     /**
      * Get the authentication details.
-     *
-     * @return array
      */
-    protected function webPushAuth()
+    protected function webPushAuth(): array
     {
         $config = [];
         $webpush = config('webpush');
@@ -64,7 +56,7 @@ class WebPushServiceProvider extends ServiceProvider
             return $config;
         }
 
-        $config['VAPID'] = compact('publicKey', 'privateKey');
+        $config['VAPID'] = ['publicKey' => $publicKey, 'privateKey' => $privateKey];
         $config['VAPID']['subject'] = $webpush['vapid']['subject'];
 
         if (empty($config['VAPID']['subject'])) {
@@ -97,7 +89,7 @@ class WebPushServiceProvider extends ServiceProvider
             $timestamp = date('Y_m_d_His', time());
 
             $this->publishes([
-                __DIR__.'/../migrations/create_push_subscriptions_table.php.stub' => database_path("migrations/{$timestamp}_create_push_subscriptions_table.php"),
+                __DIR__.'/../migrations/create_push_subscriptions_table.php.stub' => database_path(sprintf('migrations/%s_create_push_subscriptions_table.php', $timestamp)),
             ], 'migrations');
         }
     }

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -17,7 +17,7 @@ use NotificationChannels\WebPush\WebPushChannel;
 class ChannelTest extends TestCase
 {
     /** @test */
-    public function notification_can_be_sent()
+    public function notification_can_be_sent(): void
     {
         Event::fake();
 
@@ -28,7 +28,7 @@ class ChannelTest extends TestCase
 
         $webpush->shouldReceive('queueNotification')
             ->once()
-            ->withArgs(function (Subscription $subscription, string $payload, array $options = [], array $auth = []) use ($message) {
+            ->withArgs(function (Subscription $subscription, string $payload, array $options = [], array $auth = []) use ($message): true {
                 $this->assertInstanceOf(Subscription::class, $subscription);
                 $this->assertEquals('endpoint', $subscription->getEndpoint());
                 $this->assertEquals('key', $subscription->getPublicKey());
@@ -55,7 +55,7 @@ class ChannelTest extends TestCase
     }
 
     /** @test */
-    public function subscriptions_with_invalid_endpoint_are_deleted()
+    public function subscriptions_with_invalid_endpoint_are_deleted(): void
     {
         Event::fake();
 

--- a/tests/HasPushSubscriptionsTest.php
+++ b/tests/HasPushSubscriptionsTest.php
@@ -5,7 +5,7 @@ namespace NotificationChannels\WebPush\Test;
 class HasPushSubscriptionsTest extends TestCase
 {
     /** @test */
-    public function model_has_subscriptions()
+    public function model_has_subscriptions(): void
     {
         $this->createSubscription($this->testUser, 'foo');
         $this->createSubscription($this->testUser, 'bar');
@@ -16,7 +16,7 @@ class HasPushSubscriptionsTest extends TestCase
     }
 
     /** @test */
-    public function subscription_can_be_created()
+    public function subscription_can_be_created(): void
     {
         $this->testUser->updatePushSubscription('foo', 'key', 'token', 'aesgcm');
         $subscription = $this->testUser->pushSubscriptions()->first();
@@ -28,10 +28,11 @@ class HasPushSubscriptionsTest extends TestCase
     }
 
     /** @test */
-    public function exiting_subscription_can_be_updated_by_endpoint()
+    public function exiting_subscription_can_be_updated_by_endpoint(): void
     {
         $this->testUser->updatePushSubscription('foo', 'key', 'token');
         $this->testUser->updatePushSubscription('foo', 'major-key', 'another-token');
+
         $subscriptions = $this->testUser->pushSubscriptions()->where('endpoint', 'foo')->get();
 
         $this->assertEquals(1, count($subscriptions));
@@ -40,7 +41,7 @@ class HasPushSubscriptionsTest extends TestCase
     }
 
     /** @test */
-    public function determinte_if_model_owns_subscription()
+    public function determinte_if_model_owns_subscription(): void
     {
         $subscription = $this->testUser->updatePushSubscription('foo');
 
@@ -48,10 +49,11 @@ class HasPushSubscriptionsTest extends TestCase
     }
 
     /** @test */
-    public function subscription_owned_by_another_model_is_deleted_and_saved_for_the_new_model()
+    public function subscription_owned_by_another_model_is_deleted_and_saved_for_the_new_model(): void
     {
         $otherUser = $this->createUser(['email' => 'other@user.com']);
         $otherUser->updatePushSubscription('foo');
+
         $this->testUser->updatePushSubscription('foo');
 
         $this->assertEquals(0, count($otherUser->pushSubscriptions));
@@ -59,7 +61,7 @@ class HasPushSubscriptionsTest extends TestCase
     }
 
     /** @test */
-    public function subscription_can_be_deleted_by_endpoint()
+    public function subscription_can_be_deleted_by_endpoint(): void
     {
         $this->testUser->updatePushSubscription('foo');
         $this->testUser->deletePushSubscription('foo');

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -7,8 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class MessageTest extends TestCase
 {
-    /** @var \NotificationChannels\WebPush\WebPushMessage */
-    protected $message;
+    protected WebPushMessage $message;
 
     protected function setUp(): void
     {

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -10,7 +10,7 @@ class MessageTest extends TestCase
     /** @var \NotificationChannels\WebPush\WebPushMessage */
     protected $message;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -18,7 +18,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function title_can_be_set()
+    public function title_can_be_set(): void
     {
         $this->message->title('Message title');
 
@@ -26,7 +26,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function action_can_be_set()
+    public function action_can_be_set(): void
     {
         $this->message->action('Some Action', 'some_action');
 
@@ -36,7 +36,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function action_can_be_set_with_icon()
+    public function action_can_be_set_with_icon(): void
     {
         $this->message->action('Some Action', 'some_action', '/icon.png');
 
@@ -46,7 +46,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function badge_can_be_set()
+    public function badge_can_be_set(): void
     {
         $this->message->badge('/badge.jpg');
 
@@ -54,7 +54,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function body_can_be_set()
+    public function body_can_be_set(): void
     {
         $this->message->body('Message body');
 
@@ -62,7 +62,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function direction_can_be_set()
+    public function direction_can_be_set(): void
     {
         $this->message->dir('rtl');
 
@@ -70,7 +70,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function icon_can_be_set()
+    public function icon_can_be_set(): void
     {
         $this->message->icon('/icon.jpg');
 
@@ -78,7 +78,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function image_can_be_set()
+    public function image_can_be_set(): void
     {
         $this->message->image('/image.jpg');
 
@@ -86,7 +86,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function lang_can_be_set()
+    public function lang_can_be_set(): void
     {
         $this->message->lang('en');
 
@@ -94,7 +94,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function renotify_can_be_set()
+    public function renotify_can_be_set(): void
     {
         $this->message->renotify();
 
@@ -102,7 +102,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function requireInteraction_can_be_set()
+    public function require_interaction_can_be_set(): void
     {
         $this->message->requireInteraction();
 
@@ -110,7 +110,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function tag_can_be_set()
+    public function tag_can_be_set(): void
     {
         $this->message->tag('tag1');
 
@@ -118,7 +118,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function vibration_pattern_can_be_set()
+    public function vibration_pattern_can_be_set(): void
     {
         $this->message->vibrate([1, 2, 3]);
 
@@ -126,7 +126,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function arbitrary_data_can_be_set()
+    public function arbitrary_data_can_be_set(): void
     {
         $this->message->data(['id' => 1]);
 
@@ -134,7 +134,7 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function options_can_be_set()
+    public function options_can_be_set(): void
     {
         $this->message->options(['ttl' => 60]);
 

--- a/tests/PushSubscriptionModelTest.php
+++ b/tests/PushSubscriptionModelTest.php
@@ -7,7 +7,7 @@ use NotificationChannels\WebPush\PushSubscription;
 class PushSubscriptionModelTest extends TestCase
 {
     /** @test */
-    public function attributes_are_fillable()
+    public function attributes_are_fillable(): void
     {
         $subscription = new PushSubscription([
             'endpoint' => 'endpoint',
@@ -23,7 +23,7 @@ class PushSubscriptionModelTest extends TestCase
     }
 
     /** @test */
-    public function subscription_can_be_found_by_endpoint()
+    public function subscription_can_be_found_by_endpoint(): void
     {
         $this->testUser->updatePushSubscription('endpoint');
         $subscription = PushSubscription::findByEndpoint('endpoint');
@@ -32,12 +32,12 @@ class PushSubscriptionModelTest extends TestCase
     }
 
     /** @test */
-    public function subscription_has_owner_model()
+    public function subscription_has_owner_model(): void
     {
         $this->testUser->updatePushSubscription('endpoint');
         $subscription = PushSubscription::findByEndpoint('endpoint');
 
         $this->assertEquals($this->testUser->id, $subscription->subscribable_id);
-        $this->assertEquals(get_class($this->testUser), $subscription->subscribable_type);
+        $this->assertEquals($this->testUser::class, $subscription->subscribable_type);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -34,7 +34,7 @@ abstract class TestCase extends Orchestra
 
     /**
      * @param  \Illuminate\Foundation\Application  $app
-     * @return array
+     * @return array<array-key, class-string>
      */
     protected function getPackageProviders($app)
     {
@@ -61,6 +61,7 @@ abstract class TestCase extends Orchestra
     }
 
     /**
+     * @param  array<string, mixed>  $attributes
      * @return \NotificationChannels\WebPush\Test\User
      */
     public function createUser(array $attributes)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,20 +48,19 @@ abstract class TestCase extends Orchestra
      */
     protected function setUpDatabase()
     {
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', function (Blueprint $table): void {
             $table->increments('id');
             $table->string('email');
         });
 
         include_once __DIR__.'/../migrations/create_push_subscriptions_table.php.stub';
 
-        (new \CreatePushSubscriptionsTable())->up();
+        (new \CreatePushSubscriptionsTable)->up();
 
         $this->createUser(['email' => 'test@user.com']);
     }
 
     /**
-     * @param  array  $attributes
      * @return \NotificationChannels\WebPush\Test\User
      */
     public function createUser(array $attributes)
@@ -85,13 +84,12 @@ abstract class TestCase extends Orchestra
     }
 
     /**
-     * @param  string  $expectedText
      * @return void
      */
-    protected function seeInConsoleOutput($expectedText)
+    protected function seeInConsoleOutput(string $expectedText)
     {
         $consoleOutput = $this->app[Kernel::class]->output();
 
-        $this->assertStringContainsString($expectedText, $consoleOutput, "Did not see `{$expectedText}` in console output: `$consoleOutput`");
+        $this->assertStringContainsString($expectedText, $consoleOutput, sprintf('Did not see `%s` in console output: `%s`', $expectedText, $consoleOutput));
     }
 }

--- a/tests/TestNotification.php
+++ b/tests/TestNotification.php
@@ -9,12 +9,8 @@ class TestNotification extends Notification
 {
     /**
      * Get the web push representation of the notification.
-     *
-     * @param  mixed  $notifiable
-     * @param  mixed  $notification
-     * @return \NotificationChannels\WebPush\WebPushMessage
      */
-    public function toWebPush($notifiable, $notification)
+    public function toWebPush(mixed $notifiable, mixed $notification): WebPushMessage
     {
         return (new WebPushMessage)
             ->data(['id' => 1])

--- a/tests/User.php
+++ b/tests/User.php
@@ -8,7 +8,8 @@ use NotificationChannels\WebPush\HasPushSubscriptions;
 
 class User extends Authenticatable
 {
-    use Notifiable, HasPushSubscriptions;
+    use HasPushSubscriptions;
+    use Notifiable;
 
     public $timestamps = false;
 

--- a/tests/VapidKeysGenerateCommandTest.php
+++ b/tests/VapidKeysGenerateCommandTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\File;
 class VapidKeysGenerateCommandTest extends TestCase
 {
     /** @test */
-    public function it_can_generate_and_show_vapid_keys1()
+    public function it_can_generate_and_show_vapid_keys1(): void
     {
         $exitCode = Artisan::call('webpush:vapid', ['--show' => true]);
 
@@ -17,7 +17,7 @@ class VapidKeysGenerateCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_can_generate_and_show_vapid_keys2()
+    public function it_can_generate_and_show_vapid_keys2(): void
     {
         $exitCode = Artisan::call('webpush:vapid', ['--show' => true]);
 
@@ -26,7 +26,7 @@ class VapidKeysGenerateCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_can_generate_and_set_vapid_keys()
+    public function it_can_generate_and_set_vapid_keys(): void
     {
         if (File::isDirectory(__DIR__.'/temp')) {
             File::deleteDirectory(__DIR__.'/temp');


### PR DESCRIPTION
Switches to native types where possible. This might be a breaking change for existing implementations.