### PR TITLE
default content_encoding to aes128gcm

### DIFF
--- a/src/HasPushSubscriptions.php
+++ b/src/HasPushSubscriptions.php
@@ -22,6 +22,8 @@ trait HasPushSubscriptions
      */
     public function updatePushSubscription(string $endpoint, ?string $key = null, ?string $token = null, ?string $contentEncoding = null): PushSubscription
     {
+        $contentEncoding ??= 'aes128gcm';
+
         $subscription = app(config('webpush.model'))->findByEndpoint($endpoint);
 
         if ($subscription && $this->ownsPushSubscription($subscription)) {

--- a/tests/HasPushSubscriptionsTest.php
+++ b/tests/HasPushSubscriptionsTest.php
@@ -43,6 +43,15 @@ class HasPushSubscriptionsTest extends TestCase
     }
 
     #[Test]
+    public function subscription_defaults_to_aes128gcm_when_content_encoding_is_null(): void
+    {
+        $this->testUser->updatePushSubscription('foo', 'key', 'token');
+        $subscription = $this->testUser->pushSubscriptions()->first();
+
+        $this->assertEquals('aes128gcm', $subscription->content_encoding);
+    }
+
+    #[Test]
     public function determinte_if_model_owns_subscription(): void
     {
         $subscription = $this->testUser->updatePushSubscription('foo');


### PR DESCRIPTION
Closes #220.

Defaults `$contentEncoding` to `aes128gcm` (RFC 8291) in `HasPushSubscriptions::updatePushSubscription()` when null, instead of letting `minishlink/web-push` fall back to the legacy `aesgcm` draft.

Quoting maintainer @joostdebruijn in #220:
> I completely agree that updating the default encoding to aes128gcm to align with RFC 8291 is the right move for the library's future, and I'd be happy to accept a PR for this change (or I can implement it in the next standard release).

Tests cover the new default in `HasPushSubscriptionsTest::subscription_defaults_to_aes128gcm_when_content_encoding_is_null`.